### PR TITLE
Fixed working with hydration modes

### DIFF
--- a/src/ExecutableQueryObject.php
+++ b/src/ExecutableQueryObject.php
@@ -89,8 +89,14 @@ final class ExecutableQueryObject implements ExecutableQueryObjectInterface
 				->setMaxResults(NULL);
 		}
 
-		if (NULL !== $this->resultSetOptions && AbstractQuery::HYDRATE_OBJECT !== $this->resultSetOptions->getOption(ResultSetOptionsInterface::OPTION_HYDRATION_MODE, AbstractQuery::HYDRATE_OBJECT)) {
-			return $query->execute(NULL, $this->resultSetOptions->getOption(ResultSetOptionsInterface::OPTION_HYDRATION_MODE));
+		$hydrationMode = $query->getHydrationMode();
+
+		if (NULL !== $this->resultSetOptions) {
+			$hydrationMode = $this->resultSetOptions->getOption(ResultSetOptionsInterface::OPTION_HYDRATION_MODE, $hydrationMode);
+		}
+
+		if (AbstractQuery::HYDRATE_OBJECT !== $hydrationMode) {
+			return $query->execute(NULL, $hydrationMode);
 		}
 
 		return $this->lastResultSet;
@@ -101,7 +107,7 @@ final class ExecutableQueryObject implements ExecutableQueryObjectInterface
 	 *
 	 * @throws \Doctrine\ORM\NonUniqueResultException
 	 */
-	public function fetchOne(): ?object
+	public function fetchOne()
 	{
 		$query = $this->getQuery();
 

--- a/src/ExecutableQueryObjectInterface.php
+++ b/src/ExecutableQueryObjectInterface.php
@@ -23,5 +23,5 @@ interface ExecutableQueryObjectInterface
 	/**
 	 * @return object|NULL|mixed
 	 */
-	public function fetchOne(): ?object;
+	public function fetchOne();
 }

--- a/src/ResultSet/ResultSet.php
+++ b/src/ResultSet/ResultSet.php
@@ -137,7 +137,7 @@ class ResultSet implements ResultSetInterface
 		$query = $this->context->getQuery();
 		$options = $this->getOptions();
 
-		$query->setHydrationMode($options->getOption(ResultSetOptionsInterface::OPTION_HYDRATION_MODE, AbstractQuery::HYDRATE_OBJECT));
+		$query->setHydrationMode($options->getOption(ResultSetOptionsInterface::OPTION_HYDRATION_MODE, $query->getHydrationMode()));
 
 		if ($query instanceof Query && $options->getOption(ResultSetOptionsInterface::OPTION_FETCH_JOIN_COLLECTION) && (0 < $query->getMaxResults() || 0 < $query->getFirstResult())) {
 			$iterator = $this->createPaginator($query)->getIterator();

--- a/src/ResultSet/ResultSetOptions.php
+++ b/src/ResultSet/ResultSetOptions.php
@@ -10,10 +10,18 @@ class ResultSetOptions implements ResultSetOptionsInterface
 {
 	/** @var array  */
 	protected $options = [
-		self::OPTION_HYDRATION_MODE => AbstractQuery::HYDRATE_OBJECT,
+		self::OPTION_HYDRATION_MODE => NULL,
 		self::OPTION_FETCH_JOIN_COLLECTION => FALSE,
 		self::OPTION_USE_OUTPUT_WALKERS => NULL,
 	];
+
+	/**
+	 * @return \SixtyEightPublishers\DoctrineQueryObjects\ResultSet\ResultSetOptions
+	 */
+	public function create(): self
+	{
+		return new static();
+	}
 
 	/**
 	 * {@inheritDoc}


### PR DESCRIPTION
- a Query returned from a `QueryObjectInterface` can define a hydration mode itself
- removed strict return type from a method `ExecutableQueryObjectInterface::fetchOne()` - the method can returns an array or a scalar value